### PR TITLE
Fix issue #24 on upstream, wget now ignores existing files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@
 VERSION=1.0-r001
 WHOAMI=$(shell whoami)
 NGSUSER=$(WHOAMI)
+WGETOPTS="--no-clobber"
 
 ################################################################
 ## This is where we will make ngs_projects and download metadata to etc etc
@@ -168,63 +169,63 @@ b37:
 	cd $(INSTALLDIR)/ngs_projects/ngseasy_resources && \
 	mkdir -p reference_genomes_b37 && \
 	cd $(INSTALLDIR)/ngs_projects/ngseasy_resources/reference_genomes_b37 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Genome && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/GenomeIndex && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/GenomeIndexHash && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/LCR_hg19_rmsk.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/OverflowTable && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/S03723314_Regions.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/S06588914_Regions_trimmed.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/SeqCap_EZ_Exome_v3_capture.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/SeqCap_EZ_Exome_v3_primary.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/b37.genome && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/contaminant_list.fa && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.recab && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.1.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.2.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.3.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.4.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.chrom_lengths && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.amb && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.ann && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.bwt && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.fai && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.pac && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.sa && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.novoindex && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.rev.1.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.rev.2.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.sthash && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.stidx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37_0.5Kwindows.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37_1Kwindows.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/nexterarapidcapture_exome_targetedregions_v1.2.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/nexterarapidcapture_expandedexome_targetedregions.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Genome && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/GenomeIndex && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/GenomeIndexHash && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/LCR_hg19_rmsk.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/OverflowTable && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/S03723314_Regions.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/S06588914_Regions_trimmed.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/SeqCap_EZ_Exome_v3_capture.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/SeqCap_EZ_Exome_v3_primary.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/b37.genome && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/contaminant_list.fa && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.recab && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.1.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.2.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.3.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.4.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.chrom_lengths && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.amb && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.ann && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.bwt && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.fai && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.pac && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.sa && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.novoindex && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.rev.1.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.rev.2.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.sthash && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.stidx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37_0.5Kwindows.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37_1Kwindows.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/nexterarapidcapture_exome_targetedregions_v1.2.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/nexterarapidcapture_expandedexome_targetedregions.bed && \
 	chmod -R 775 $(INSTALLDIR)/ngs_projects/ngseasy_resources/reference_genomes_b37/
 
 # hg19 Genomes idexed and resources
@@ -234,64 +235,64 @@ hg19:
 	cd $(INSTALLDIR)/ngs_projects/ngseasy_resources && \
 	mkdir -p reference_genomes_hg19 && \
 	cd $(INSTALLDIR)/ngs_projects/ngseasy_resources/reference_genomes_hg19 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_omni2.5.hg19.sites.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_omni2.5.hg19.sites.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_phase1.indels.hg19.sites.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_phase1.indels.hg19.sites.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_phase1.snps.high_confidence.hg19.sites.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_phase1.snps.high_confidence.hg19.sites.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/CEUTrio.HiSeq.WGS.b37.bestPractices.hg19.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/CEUTrio.HiSeq.WGS.b37.bestPractices.hg19.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/Genome && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/GenomeIndex && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/GenomeIndexHash && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/Mills_and_1000G_gold_standard.indels.hg19.sites.vcf.gz && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/Mills_and_1000G_gold_standard.indels.hg19.sites.vcf.gz.tbi && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/Mills_and_1000G_gold_standard.indels.hg19.sites.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.hg19.sites.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.hg19.sites.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.hg19.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.hg19.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.knowledgebase.snapshot.20131119.hg19.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.knowledgebase.snapshot.20131119.hg19.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/OverflowTable && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/contaminant_list.fa && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/dbsnp_138.hg19.excluding_sites_after_129.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/dbsnp_138.hg19.excluding_sites_after_129.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/dbsnp_138.hg19.recab && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/dbsnp_138.hg19.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/dbsnp_138.hg19.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/get_hg19.sh && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/get_hg19_others.sh && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/hapmap_3.3.hg19.sites.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/hapmap_3.3.hg19.sites.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/hg19.genome && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/index_bowtie.sh && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/index_bwa.sh && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/index_novo.sh && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/index_snap.sh && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/index_stampy.sh && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19-bs.umfa && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.1.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.2.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.3.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.4.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.dict && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fai && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.amb && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.ann && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.bwt && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.fai && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.fai.gz && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.gz && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.novoindex && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.pac && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.sa && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.rev.1.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.rev.2.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.sthash && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.stidx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_omni2.5.hg19.sites.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_omni2.5.hg19.sites.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_phase1.indels.hg19.sites.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_phase1.indels.hg19.sites.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_phase1.snps.high_confidence.hg19.sites.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/1000G_phase1.snps.high_confidence.hg19.sites.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/CEUTrio.HiSeq.WGS.b37.bestPractices.hg19.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/CEUTrio.HiSeq.WGS.b37.bestPractices.hg19.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/Genome && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/GenomeIndex && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/GenomeIndexHash && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/Mills_and_1000G_gold_standard.indels.hg19.sites.vcf.gz && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/Mills_and_1000G_gold_standard.indels.hg19.sites.vcf.gz.tbi && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/Mills_and_1000G_gold_standard.indels.hg19.sites.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.hg19.sites.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.hg19.sites.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.hg19.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.hg19.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.knowledgebase.snapshot.20131119.hg19.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/NA12878.knowledgebase.snapshot.20131119.hg19.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/OverflowTable && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/contaminant_list.fa && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/dbsnp_138.hg19.excluding_sites_after_129.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/dbsnp_138.hg19.excluding_sites_after_129.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/dbsnp_138.hg19.recab && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/dbsnp_138.hg19.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/dbsnp_138.hg19.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/get_hg19.sh && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/get_hg19_others.sh && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/hapmap_3.3.hg19.sites.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/hapmap_3.3.hg19.sites.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/hg19.genome && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/index_bowtie.sh && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/index_bwa.sh && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/index_novo.sh && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/index_snap.sh && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/index_stampy.sh && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19-bs.umfa && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.1.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.2.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.3.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.4.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.dict && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fai && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.amb && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.ann && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.bwt && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.fai && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.fai.gz && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.gz && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.novoindex && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.pac && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.fasta.sa && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.rev.1.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.rev.2.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.sthash && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hg19/ucsc.hg19.stidx && \
 	chmod -R 775 $(INSTALLDIR)/ngs_projects/ngseasy_resources/reference_genomes_hg19/
 
 ## hs37d5
@@ -300,61 +301,61 @@ hs37d5:
 	cd $(INSTALLDIR)/ngs_projects/ngseasy_resources && \
 	mkdir -p reference_genomes_hs37d5 && \
 	cd $(INSTALLDIR)/ngs_projects/ngseasy_resources/reference_genomes_hs37d5 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_omni2.5.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_omni2.5.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_phase1.indels.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_phase1.indels.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_phase1.snps.high_confidence.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_phase1.snps.high_confidence.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/CEUTrio.HiSeq.WGS.b37.NA12878.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/CEUTrio.HiSeq.WGS.b37.NA12878.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/contaminant_list.fa && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/dbsnp_138.b37.excluding_sites_after_129.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/dbsnp_138.b37.excluding_sites_after_129.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/dbsnp_138.b37.recab && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/dbsnp_138.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/dbsnp_138.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/Genome && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/GenomeIndex && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/GenomeIndexHash && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hapmap_3.3.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hapmap_3.3.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.1.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.2.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.3.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.4.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.amb && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.ann && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.bwt && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.fai && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.novoindex && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.pac && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.sa && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.rev.1.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.rev.2.bt2 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.sthash && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.stidx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/human_g1k_v37_0.5Kwindows.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/human_g1k_v37_1Kwindows.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/LCR_hg19_rmsk.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/Mills_and_1000G_gold_standard.indels.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/Mills_and_1000G_gold_standard.indels.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.knowledgebase.snapshot.20131119.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.knowledgebase.snapshot.20131119.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/nexterarapidcapture_exome_targetedregions_v1.2.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/nexterarapidcapture_expandedexome_targetedregions.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/OverflowTable && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/S03723314_Regions.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/S06588914_Regions_trimmed.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/SeqCap_EZ_Exome_v3_capture.bed && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/SeqCap_EZ_Exome_v3_primary.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_omni2.5.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_omni2.5.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_phase1.indels.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_phase1.indels.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_phase1.snps.high_confidence.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/1000G_phase1.snps.high_confidence.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/CEUTrio.HiSeq.WGS.b37.NA12878.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/CEUTrio.HiSeq.WGS.b37.NA12878.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/contaminant_list.fa && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/dbsnp_138.b37.excluding_sites_after_129.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/dbsnp_138.b37.excluding_sites_after_129.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/dbsnp_138.b37.recab && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/dbsnp_138.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/dbsnp_138.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/Genome && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/GenomeIndex && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/GenomeIndexHash && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hapmap_3.3.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hapmap_3.3.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.1.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.2.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.3.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.4.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.amb && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.ann && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.bwt && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.fai && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.novoindex && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.pac && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.fasta.sa && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.rev.1.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.rev.2.bt2 && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.sthash && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/hs37d5.stidx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/human_g1k_v37_0.5Kwindows.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/human_g1k_v37_1Kwindows.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/LCR_hg19_rmsk.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/Mills_and_1000G_gold_standard.indels.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/Mills_and_1000G_gold_standard.indels.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.knowledgebase.snapshot.20131119.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/NA12878.knowledgebase.snapshot.20131119.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/nexterarapidcapture_exome_targetedregions_v1.2.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/nexterarapidcapture_expandedexome_targetedregions.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/OverflowTable && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/S03723314_Regions.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/S06588914_Regions_trimmed.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/SeqCap_EZ_Exome_v3_capture.bed && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_hs37d5/SeqCap_EZ_Exome_v3_primary.bed && \
 	chmod -R 775 $(INSTALLDIR)/ngs_projects/ngseasy_resources/reference_genomes_hs37d5/
 
 ##  Test data and stick it in raw_fastq
@@ -363,17 +364,17 @@ hs37d5:
 testdata: ngsprojectdir
 	@echo "Get Test data and stick it in raw_fastq"
 	cd $(INSTALLDIR)/ngs_projects/raw_fastq && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/ && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/illumina.100bp.pe.wex.150x_1.fastq.gz && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/illumina.100bp.pe.wex.150x_2.fastq.gz && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/illumina.100bp.pe.wex.30x_1.fastq.gz && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/illumina.100bp.pe.wex.30x_2.fastq.gz && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/ && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/illumina.100bp.pe.wex.150x_1.fastq.gz && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/illumina.100bp.pe.wex.150x_2.fastq.gz && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/illumina.100bp.pe.wex.30x_1.fastq.gz && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/illumina.100bp.pe.wex.30x_2.fastq.gz && \
 	chmod -R 775 $(INSTALLDIR)/ngs_projects/raw_fastq/ && \
 	cd $(INSTALLDIR)/ngs_projects/config_files && \
 	cp -v $(DIR)/test/ngseasy_test.config.tsv $(INSTALLDIR)/ngs_projects/config_files/ && \
 	chmod -R 775 $(INSTALLDIR)/ngs_projects/config_files/
-##	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/NA12878D_HiSeqX_R1.fastq.gz && \
-##	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/NA12878D_HiSeqX_R2.fastq.gz && \
+##	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/NA12878D_HiSeqX_R1.fastq.gz && \
+##	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/fastq_test_data/NA12878D_HiSeqX_R2.fastq.gz && \
 
 ## Manual Builds
 gatk:
@@ -426,40 +427,40 @@ purgegenomes:
 bwab37indexes: ngsprojectdir
 	@echo "Getting bwa b37 resources"
 	cd $(INSTALLDIR)/ngs_resources/reference_genomes_b37 && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/contaminant_list.fa && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.recab && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf.idx && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.chrom_lengths && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.amb && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.ann && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.bwt && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.fai && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.pac && \
-	wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.sa && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/contaminant_list.fa && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.recab && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf.idx && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.chrom_lengths && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.amb && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.ann && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.bwt && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.fai && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.pac && \
+	wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta.sa && \
 	chmod -R 775 $(INSTALLDIR)/ngs_projects/ngseasy_resources/reference_genomes_b37/
 
 ############################################################################
@@ -467,35 +468,35 @@ bwab37indexes: ngsprojectdir
 novoalignb37indexes: ngsprojectdir
 		@echo "Getting novoalign b37 resources"
 		cd $(INSTALLDIR)/ngs_resources/reference_genomes_b37 && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/contaminant_list.fa && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.recab && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf.idx && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.chrom_lengths && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta && \
-		wget https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.novoindex && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_omni2.5.b37.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.indels.b37.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/1000G_phase1.snps.high_confidence.b37.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.NA12878.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/CEUTrio.HiSeq.WGS.b37.bestPractices.b37.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/Mills_and_1000G_gold_standard.indels.b37.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.sites.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.HiSeq.WGS.bwa.cleaned.raw.subset.b37.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/NA12878.knowledgebase.snapshot.20131119.b37.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/contaminant_list.fa && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.excluding_sites_after_129.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.recab && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/dbsnp_138.b37.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/hapmap_3.3.b37.vcf.idx && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.chrom_lengths && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.fasta && \
+		wget $(WGETOPTS) https://s3-eu-west-1.amazonaws.com/ngseasy.data/reference_genomes_b37/human_g1k_v37.novoindex && \
 		chmod -R 775 $(INSTALLDIR)/ngs_projects/ngseasy_resources/reference_genomes_b37/
 
 ############################################################################


### PR DESCRIPTION
Users may use WGETOPTS="--no-clobber" (default) to ignore existing huge resource files. Like this:
`
make INSTALLDIR="/home/$USER"  WGETOPTS="--no-clobber" 
`

In case timestamps on the files were not changed, users may use `WGETOPTS="--timestamping"` instead.  

A better solution would be:
`Upstream` compresses those plain text files to save download traffic, and compute checksums (SHA256 or MD5) for them. The "Makefile" then can do some smart things, e.g. checking data integrity, comparing checksum and only download if neccessary.
